### PR TITLE
Bugfix for systems which default to unsigned chars

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(nfc3d C)
 include_directories(include)
 
 if(CMAKE_COMPILER_IS_GNUCC)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fsigned-char")
 endif()
 
 set(HEADER_FILES


### PR DESCRIPTION
Systems which default to unsigned chars (like the Raspberry Pi 2) weren't able to handle getopt() correctly because they could not check against the return value -1. Appending a flag to the GCC compiler can handle this problem.